### PR TITLE
V0.43.0 hmhco

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM public.ecr.aws/docker/library/golang:1.18.4-alpine3.15 as build
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY . /go
+
+RUN cd /go/control-plane && \
+	set -x; go build -o pkg/bin/consul-k8s-control-plane
+
+# final image
+# we are simply copying our custom built binary over the standard binary in the image
+# If we need to upgrade past 1.12.x this line should be updated to reflect that
+FROM hashicorp/consul-k8s-control-plane:0.43.0
+
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY --from=build /go/control-plane/pkg/bin/ /bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
 FROM public.ecr.aws/docker/library/golang:1.18.4-alpine3.15 as build
-ARG TARGETOS
-ARG TARGETARCH
-
 COPY . /go
 
 RUN cd /go/control-plane && \
@@ -11,8 +8,5 @@ RUN cd /go/control-plane && \
 # we are simply copying our custom built binary over the standard binary in the image
 # If we need to upgrade past 1.12.x this line should be updated to reflect that
 FROM hashicorp/consul-k8s-control-plane:0.43.0
-
-ARG TARGETOS
-ARG TARGETARCH
 
 COPY --from=build /go/control-plane/pkg/bin/ /bin

--- a/HMH-README.md
+++ b/HMH-README.md
@@ -4,9 +4,19 @@ This must be built from a linux machine, will not work on m1 mac.
 
 #### 0.12.x
 ```
+git clone https://github.com/pveasey/consul-k8s
+cd consul-k8s/
 git checkout v0.43.0-hmhco
-docker build . -t docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.43.0-veaseyp
-docker push docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.43.0-veaseyp
+docker build . -t docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.43.0-veaseyp-2
+docker push docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.43.0-veaseyp-1
 ```
 
 #### future releases
+first checkout hashicorp target tag 
+
+#               our branch   hashicorps tag
+git checkout -b v0.X.X-hmhco v0.x.x 
+
+add the changes in this commit 
+https://github.com/Pveasey/consul-k8s/commit/3fb8965c5848abc9c1f39a23fc7a12134290ccb7
+

--- a/HMH-README.md
+++ b/HMH-README.md
@@ -1,0 +1,12 @@
+### Building
+
+This must be built from a linux machine, will not work on m1 mac.
+
+#### 0.12.x
+```
+git checkout v0.43.0-hmhco
+docker build . -t docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.43.0-veaseyp
+docker push docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.43.0-veaseyp
+```
+
+#### future releases

--- a/HMH-README.md
+++ b/HMH-README.md
@@ -4,11 +4,11 @@ This must be built from a linux machine, will not work on m1 mac.
 
 #### 0.12.x
 ```
-git clone https://github.com/pveasey/consul-k8s
+git clone https://github.com/hmhco/consul-k8s
 cd consul-k8s/
 git checkout v0.43.0-hmhco
-docker build . -t docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.43.0-veaseyp-2
-docker push docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.43.0-veaseyp-1
+docker build . -t docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.43.0-hmhco-1
+docker push docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.43.0-hmhco-1
 ```
 
 #### future releases

--- a/HMH-README.md
+++ b/HMH-README.md
@@ -17,6 +17,7 @@ first checkout hashicorp target tag
 #               our branch   hashicorps tag
 git checkout -b v0.X.X-hmhco v0.x.x 
 
-add the changes in this commit 
-https://github.com/Pveasey/consul-k8s/commit/3fb8965c5848abc9c1f39a23fc7a12134290ccb7
+add the go changes and dockerfile like this PR
+https://github.com/hmhco/consul-k8s/pull/1/
 
+You will need to update the `FROM hashicorp/consul-k8s-control-plane:0.43.0` to match the target version of the build

--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -86,6 +86,9 @@ const (
 	annotationConsulSidecarMemoryLimit   = "consul.hashicorp.com/consul-sidecar-memory-limit"
 	annotationConsulSidecarMemoryRequest = "consul.hashicorp.com/consul-sidecar-memory-request"
 
+	// annotationSidecarProxyPreStopDelay is the number of seconds to delay Envoy Sidecar shutdown
+	annotationSidecarProxyPreStopDelay = "consul.hashicorp.com/sidecar-proxy-prestop-delay"
+
 	// annotations for metrics to configure where Prometheus scrapes
 	// metrics from, whether to run a merged metrics endpoint on the consul
 	// sidecar, and configure the connect service metrics.

--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -87,6 +87,7 @@ const (
 	annotationConsulSidecarMemoryRequest = "consul.hashicorp.com/consul-sidecar-memory-request"
 
 	// annotationSidecarProxyPreStopDelay is the number of seconds to delay Envoy Sidecar shutdown
+	// set to 0 to have no delay, defaults to 1 second
 	annotationSidecarProxyPreStopDelay = "consul.hashicorp.com/sidecar-proxy-prestop-delay"
 
 	// annotations for metrics to configure where Prometheus scrapes

--- a/control-plane/connect-inject/envoy_sidecar.go
+++ b/control-plane/connect-inject/envoy_sidecar.go
@@ -48,7 +48,7 @@ func (h *Handler) envoySidecar(namespace corev1.Namespace, pod corev1.Pod, mpi m
 		Command: cmd,
 	}
 
-    lifecycle, err := h.envoySidecarLifecycle(pod)
+	lifecycle, err := h.envoySidecarLifecycle(pod)
 	if err == nil {
 		container.Lifecycle = lifecycle
 	}
@@ -132,10 +132,10 @@ func (h *Handler) envoySidecarLifecycle(pod corev1.Pod) (*corev1.Lifecycle, erro
 
 	delay, annotationSet := pod.Annotations[annotationSidecarProxyPreStopDelay]
 
-    //default delay with no annotationSidecarProxyPreStopDelay set
-    // With testing in sandbox with consul 1.12.8 - 1 second appears to be too slow in some cases
-    // never seen it fail requests with 2 second delay but will
-    // default 3 seconds to have ample time to de-register consul service
+	//default delay with no annotationSidecarProxyPreStopDelay set
+	// With testing in sandbox with consul 1.12.8 - 1 second appears to be too slow in some cases
+	// never seen it fail requests with 2 second delay but will
+	// default 3 seconds to have ample time to de-register consul service
 	if !annotationSet {
 		delay = "3"
 	}

--- a/control-plane/connect-inject/envoy_sidecar.go
+++ b/control-plane/connect-inject/envoy_sidecar.go
@@ -132,8 +132,9 @@ func (h *Handler) envoySidecarLifecycle(pod corev1.Pod) (*corev1.Lifecycle, erro
 
 	delay, annotationSet := pod.Annotations[annotationSidecarProxyPreStopDelay]
 
+    //default 1 second delay with no annotation set for annotationSidecarProxyPreStopDelay
 	if !annotationSet {
-		return &corev1.Lifecycle{}, fmt.Errorf("Annotation not set")
+		delay := 1
 	}
 
 	lifecycle := &corev1.Lifecycle{

--- a/control-plane/connect-inject/envoy_sidecar.go
+++ b/control-plane/connect-inject/envoy_sidecar.go
@@ -132,9 +132,12 @@ func (h *Handler) envoySidecarLifecycle(pod corev1.Pod) (*corev1.Lifecycle, erro
 
 	delay, annotationSet := pod.Annotations[annotationSidecarProxyPreStopDelay]
 
-    //default 1 second delay with no annotation set for annotationSidecarProxyPreStopDelay
+    //default delay with no annotationSidecarProxyPreStopDelay set
+    // With testing in sandbox with consul 1.12.8 - 1 second appears to be too slow in some cases
+    // never seen it fail requests with 2 second delay but will
+    // default 3 seconds to have ample time to de-register consul service
 	if !annotationSet {
-		delay := 1
+		delay = "3"
 	}
 
 	lifecycle := &corev1.Lifecycle{


### PR DESCRIPTION
Per BEDROCK-6218

See:
https://discuss.hashicorp.com/t/delay-sigterm-of-envoy-sidecar-proxy/22036/3
https://github.com/hashicorp/consul-k8s/issues/536
for more detailed explanation of the issue    

upgrades to consul k8s will break gracefulness of ingress, this PR adds a default delay of 3 seconds for the envoy sidecar. This allows enough time for consul service to be deregistered before envoy gets a SIGTERM

i have opened a ticket with hashicorp and linked this code along with details why. 
They confirmed this solution is feasible approach atm.

Changes proposed in this PR:
-
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

