### PR TITLE
Release 0.49.5 supporting Consul@1.13.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/docker/library/golang:1.19.2-alpine as build
+COPY . /go
+
+RUN cd /go/control-plane && \
+	set -x; go build -o pkg/bin/consul-k8s-control-plane
+
+# final image
+# we are simply copying our custom built binary over the standard binary in the image
+# If we need to upgrade past 1.13.x this line should be updated to reflect that
+FROM hashicorp/consul-k8s-control-plane:0.49.5
+
+COPY --from=build /go/control-plane/pkg/bin/ /bin 
+

--- a/HMH-README.md
+++ b/HMH-README.md
@@ -1,0 +1,30 @@
+### Building
+
+#### 1.12.x
+```
+git clone https://github.com/hmhco/consul-k8s
+cd consul-k8s/
+git checkout v0.49.5-hmhco
+docker buildx build --platform linux/amd64 . -t docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.49.5-hmhco-1
+docker push docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.49.5-hmhco-1
+```
+
+#### 1.12.x
+```
+git clone https://github.com/hmhco/consul-k8s
+cd consul-k8s/
+git checkout v0.43.0-hmhco
+docker build . -t docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.43.0-hmhco-1
+docker push docker.br.hmheng.io/kubernetes/consul-k8s-control-plane:0.43.0-hmhco-1
+```
+
+#### future releases
+first checkout hashicorp target tag 
+
+#               our branch   hashicorps tag
+git checkout -b v0.X.X-hmhco v0.x.x 
+
+add the go changes and dockerfile like this PR
+https://github.com/hmhco/consul-k8s/pull/1/
+
+You will need to update the `FROM hashicorp/consul-k8s-control-plane:0.49.5` to match the target version of the build

--- a/HMH-README.md
+++ b/HMH-README.md
@@ -1,6 +1,6 @@
 ### Building
 
-#### 1.12.x
+#### 1.13.x
 ```
 git clone https://github.com/hmhco/consul-k8s
 cd consul-k8s/

--- a/control-plane/connect-inject/annotations.go
+++ b/control-plane/connect-inject/annotations.go
@@ -95,6 +95,10 @@ const (
 	annotationConsulSidecarMemoryLimit   = "consul.hashicorp.com/consul-sidecar-memory-limit"
 	annotationConsulSidecarMemoryRequest = "consul.hashicorp.com/consul-sidecar-memory-request"
 
+	// annotationSidecarProxyPreStopDelay is the number of seconds to delay Envoy Sidecar shutdown
+	// set to 0 to have no delay, defaults to 3 seconds
+	annotationSidecarProxyPreStopDelay = "consul.hashicorp.com/sidecar-proxy-prestop-delay"
+
 	// annotations for sidecar volumes.
 	annotationConsulSidecarUserVolume      = "consul.hashicorp.com/consul-sidecar-user-volume"
 	annotationConsulSidecarUserVolumeMount = "consul.hashicorp.com/consul-sidecar-user-volume-mount"


### PR DESCRIPTION
Per BEDROCK-6218/BEDROCK-6425

See:
https://discuss.hashicorp.com/t/delay-sigterm-of-envoy-sidecar-proxy/22036/3
https://github.com/hashicorp/consul-k8s/issues/536
for more detailed explanation of the issue

upgrades to consul k8s will break gracefulness of ingress, this PR adds a default delay of 3 seconds for the envoy sidecar. This allows enough time for consul service to be deregistered before envoy gets a SIGTERM


Changes proposed in this PR:
-
-

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

